### PR TITLE
Change datepicker to datetimepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "angular-gettext": "2.3.8",
     "angular-route": "1.3.14",
     "bootstrap": "3.3.7",
-    "bootstrap-datepicker": "1.4.0",
+    "bootstrap-datetime-picker": "2.4.4",
     "c3": "0.4.13",
     "d3": "3.5.5",
     "jquery": "2.1.4",

--- a/pkg/session_recording/recordings.css
+++ b/pkg/session_recording/recordings.css
@@ -335,3 +335,15 @@ a.disabled {
 table.listing-ct > thead th:last-child, tr.listing-ct-item td:last-child {
     text-align: left !important;
 }
+
+.date {
+    width: 185px;
+}
+
+.invalid {
+    background-color: #ffdddd;
+}
+
+.valid {
+    background-color: #ffffff;
+}


### PR DESCRIPTION
I've switched datepicker to datetimepicker.
Before this one I wanted to use another one ( eonasdan-bootstrap-datetimepicker which is already inside patternfly node package, the previous datepicker was also there BTW ( cockpit/node_modules/patternfly/node_modules/datepicker - which is sort of a strange ) ), but got stuck with error inside react-lite ( https://github.com/Lucifier129/react-lite/issues/90 ).
In terms of #27 there are still some items, which I will need to cover before closing this PR.
Here is the video: https://youtu.be/qxhwRbtU0SQ
Also, probably it will need some design changes - I want to discuss this.